### PR TITLE
Fix incorrect manifest names due to symlinks pointing into /private not resolving correctly

### DIFF
--- a/MunkiAdmin/MAMunkiAdmin_AppDelegate.m
+++ b/MunkiAdmin/MAMunkiAdmin_AppDelegate.m
@@ -1021,6 +1021,11 @@ DDLogLevel ddLogLevel;
     }
     
     /*
+     Let URLByResolvingSymlinksInPath work on directory since file is not created yet
+     */
+    newURL = [[[newURL URLByDeletingLastPathComponent] URLByResolvingSymlinksInPath] URLByAppendingPathComponent: [newURL lastPathComponent]];
+
+    /*
      The actual renaming is handled by MunkiRepositoryManager
      */
     [[MAMunkiRepositoryManager sharedManager] moveManifest:selectedManifest toURL:newURL cascade:YES];
@@ -1059,6 +1064,11 @@ DDLogLevel ddLogLevel;
         return;
     }
     
+    /*
+     Let URLByResolvingSymlinksInPath work on directory since file is not created yet
+     */
+    newURL = [[[newURL URLByDeletingLastPathComponent] URLByResolvingSymlinksInPath] URLByAppendingPathComponent: [newURL lastPathComponent]];
+
     if ([[NSFileManager defaultManager] copyItemAtURL:currentURL toURL:newURL error:nil]) {
         
         MARelationshipScanner *manifestRelationships = [MARelationshipScanner manifestScanner];
@@ -1149,7 +1159,12 @@ DDLogLevel ddLogLevel;
         return;
     }
     
-    ManifestMO *newManifest = [[MACoreDataManager sharedManager] createManifestWithURL:newURL inManagedObjectContext:self.managedObjectContext];
+    /*
+     Let URLByResolvingSymlinksInPath work on directory since file is not created yet
+     */
+    newURL = [[[newURL URLByDeletingLastPathComponent] URLByResolvingSymlinksInPath] URLByAppendingPathComponent: [newURL lastPathComponent]];
+
+    ManifestMO *newManifest = [[MACoreDataManager sharedManager] createManifestWithURL:[newURL URLByResolvingSymlinksInPath] inManagedObjectContext:self.managedObjectContext];
     if (!newManifest) {
         DDLogError(@"Failed to create manifest");
     }
@@ -2571,7 +2586,7 @@ DDLogLevel ddLogLevel;
             /*
              Manifest name should be the relative path from manifests subdirectory
              */
-            NSArray *manifestComponents = [aManifestFile pathComponents];
+            NSArray *manifestComponents = [[aManifestFile URLByResolvingSymlinksInPath] pathComponents];
             NSArray *manifestDirComponents = [self.manifestsURL pathComponents];
             NSMutableArray *relativePathComponents = [NSMutableArray arrayWithArray:manifestComponents];
             [relativePathComponents removeObjectsInArray:manifestDirComponents];
@@ -2586,7 +2601,7 @@ DDLogLevel ddLogLevel;
 			if (foundItems == 0) {
 				manifest = [NSEntityDescription insertNewObjectForEntityForName:@"Manifest" inManagedObjectContext:moc];
 				manifest.title = manifestRelativePath;
-				manifest.manifestURL = aManifestFile;
+				manifest.manifestURL = [aManifestFile URLByResolvingSymlinksInPath];
 			}
 			
 		}


### PR DESCRIPTION
`URLByResolvingSymlinksInPath` does [weird things regarding symlinks in `/private`](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSURL_Class/#//apple_ref/occ/instp/NSURL/URLByResolvingSymlinksInPath).

When a repo is in, say, `/var/www/munki` (which is actually `/private/var/www/munki`), `URLByResolvingSymlinksInPath` defies logic (mine at least) and strips off the `/private` part. This causes the path component comparison to add it a faulty `private/` prefix to all manifest names. To see what I mean just create a test repo in `/var/www/munki` and create a manifest with the current Stable MunkiAdmin.

We can fix this in `scanCurrentRepoForManifests` by just running `URLByResolvingSymlinksInPath` on the scanned paths as well.

But for all the other functions in this PR, the file named by `newURL` returned from the file dialog doesn't exist yet. [By design](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSURL_Class/#//apple_ref/occ/instp/NSURL/URLByResolvingSymlinksInPath), `URLByResolvingSymlinksInPath` just returns the same path with `/private` still in it, breaking the path component comparison. In these functions we can split the directory and file name, run `URLByResolvingSymlinksInPath` on the directory, and then merge them back together.

Now manifest names are detected correctly when loading, creating, renaming, and duplicating.