### PR TITLE
Add startosinstall type to smart installer types

### DIFF
--- a/MunkiAdmin/Singletons/MACoreDataManager.m
+++ b/MunkiAdmin/Singletons/MACoreDataManager.m
@@ -662,7 +662,15 @@ DDLogLevel ddLogLevel;
     appleUpdatesSmartItem.parent = mainTypesItem;
     appleUpdatesSmartItem.originalIndexValue = 40;
     appleUpdatesSmartItem.filterPredicate = [NSPredicate predicateWithFormat:@"munki_installer_type == %@", @"apple_update_metadata"];
-    
+
+    InstallerTypeSourceListItemMO *startosinstallSmartItem = [NSEntityDescription insertNewObjectForEntityForName:@"InstallerTypeSourceListItem" inManagedObjectContext:moc];
+    startosinstallSmartItem.title = @"startosinstall";
+    startosinstallSmartItem.icon = smartIcon;
+    startosinstallSmartItem.itemType = @"smart";
+    startosinstallSmartItem.parent = mainTypesItem;
+    startosinstallSmartItem.originalIndexValue = 45;
+    startosinstallSmartItem.filterPredicate = [NSPredicate predicateWithFormat:@"munki_installer_type == %@", @"startosinstall"];
+
     InstallerTypeSourceListItemMO *configurationProfilesSmartItem = [NSEntityDescription insertNewObjectForEntityForName:@"InstallerTypeSourceListItem" inManagedObjectContext:moc];
     configurationProfilesSmartItem.title = @"Configuration Profile";
     configurationProfilesSmartItem.icon = smartIcon;


### PR DESCRIPTION
Will appear in the left sidebar as indicated by the blue line:

![Screen Shot 2019-06-06 at 3 45 56 PM](https://user-images.githubusercontent.com/7801391/59071223-95a86080-8872-11e9-903d-639800337e4c.png)
