### PR TITLE
Performance optimizations to reduce large repository loading time

### DIFF
--- a/MunkiAdmin/MAMunkiAdmin_AppDelegate.m
+++ b/MunkiAdmin/MAMunkiAdmin_AppDelegate.m
@@ -2447,6 +2447,8 @@ DDLogLevel ddLogLevel;
     DDLogVerbose(@"%@", NSStringFromSelector(_cmd));
 	DDLogDebug(@"Opening repository at %@", [newURL path]);
     
+    NSDate *repoLoadStartTime = [NSDate date];
+    
     [self stopObservingObjectsForChanges];
     [[self.managedObjectContext undoManager] disableUndoRegistration];
     [self disableAllBindings];
@@ -2483,6 +2485,35 @@ DDLogLevel ddLogLevel;
             self.iconsURL = [[self.repoURL URLByAppendingPathComponent:@"icons"] URLByResolvingSymlinksInPath];
             
             [self.defaults setURL:self.repoURL forKey:@"selectedRepositoryPath"];
+            
+        NSTimeInterval setupTime = [[NSDate date] timeIntervalSinceDate:repoLoadStartTime];
+            DDLogDebug(@"Repository setup completed in %.2f ms", setupTime * 1000.0);
+            
+            // Count files to process for performance baseline
+            NSFileManager *fm = [NSFileManager defaultManager];
+            NSDirectoryEnumerator *pkginfoEnum = [fm enumeratorAtURL:self.pkgsInfoURL includingPropertiesForKeys:@[NSURLIsRegularFileKey] options:(NSDirectoryEnumerationSkipsPackageDescendants | NSDirectoryEnumerationSkipsHiddenFiles) errorHandler:nil];
+            NSDirectoryEnumerator *manifestEnum = [fm enumeratorAtURL:self.manifestsURL includingPropertiesForKeys:@[NSURLIsRegularFileKey] options:(NSDirectoryEnumerationSkipsPackageDescendants | NSDirectoryEnumerationSkipsHiddenFiles) errorHandler:nil];
+            NSDirectoryEnumerator *catalogEnum = [fm enumeratorAtURL:self.catalogsURL includingPropertiesForKeys:@[NSURLIsRegularFileKey] options:(NSDirectoryEnumerationSkipsPackageDescendants | NSDirectoryEnumerationSkipsHiddenFiles) errorHandler:nil];
+            
+            NSUInteger pkginfoCount = 0, manifestCount = 0, catalogCount = 0;
+            for (NSURL *url in pkginfoEnum) {
+                NSNumber *isRegularFile;
+                [url getResourceValue:&isRegularFile forKey:NSURLIsRegularFileKey error:nil];
+                if ([isRegularFile boolValue]) pkginfoCount++;
+            }
+            for (NSURL *url in manifestEnum) {
+                NSNumber *isRegularFile;
+                [url getResourceValue:&isRegularFile forKey:NSURLIsRegularFileKey error:nil];
+                if ([isRegularFile boolValue]) manifestCount++;
+            }
+            for (NSURL *url in catalogEnum) {
+                NSNumber *isRegularFile;
+                [url getResourceValue:&isRegularFile forKey:NSURLIsRegularFileKey error:nil];
+                if ([isRegularFile boolValue]) catalogCount++;
+            }
+            
+            DDLogDebug(@"Repository contains: %lu packages, %lu manifests, %lu catalogs", 
+                      (unsigned long)pkginfoCount, (unsigned long)manifestCount, (unsigned long)catalogCount);
             
 			[self scanCurrentRepoForCatalogFiles];
             [self scanCurrentRepoForPackages];
@@ -2540,6 +2571,7 @@ DDLogLevel ddLogLevel;
      Scan the current repo for already existing pkginfo files
      and create a new Package object for each of them
 	*/
+    NSDate *packageScanStartTime = [NSDate date];
 	DDLogDebug(@"Scanning selected repo for packages");
 	
     /*
@@ -2584,6 +2616,9 @@ DDLogLevel ddLogLevel;
 	}
     
     [self.operationQueue addOperation:packageRelationships];
+    
+    NSTimeInterval packageScanTime = [[NSDate date] timeIntervalSinceDate:packageScanStartTime];
+    DDLogDebug(@"Package scanning setup completed in %.2f ms", packageScanTime * 1000.0);
 }
 
 - (void)scanCurrentRepoForCatalogFiles
@@ -2592,6 +2627,7 @@ DDLogLevel ddLogLevel;
      Scan the current repo for already existing catalog files
      and create a new Catalog object for each of them
      */
+    NSDate *catalogScanStartTime = [NSDate date];
 	DDLogDebug(@"Scanning selected repo for catalogs");
 	
 	NSArray *keysToget = @[NSURLNameKey, NSURLIsDirectoryKey];
@@ -2624,6 +2660,9 @@ DDLogLevel ddLogLevel;
 			}
 		}
 	}
+    
+    NSTimeInterval catalogScanTime = [[NSDate date] timeIntervalSinceDate:catalogScanStartTime];
+    DDLogDebug(@"Catalog scanning completed in %.2f ms", catalogScanTime * 1000.0);
 }
 
 
@@ -2633,6 +2672,7 @@ DDLogLevel ddLogLevel;
 	 Scan the current repo for already existing manifest files
 	 and create a new Manifest object for each of them
      */
+    NSDate *manifestScanStartTime = [NSDate date];
 	DDLogDebug(@"Scanning selected repo for manifests");
 	
 	NSArray *keysToget = @[NSURLNameKey, NSURLIsDirectoryKey];
@@ -2703,6 +2743,9 @@ DDLogLevel ddLogLevel;
     }];
     [startObservingChangesOp addDependency:saveMainContext];
     [self.operationQueue addOperation:startObservingChangesOp];
+    
+    NSTimeInterval manifestScanTime = [[NSDate date] timeIntervalSinceDate:manifestScanStartTime];
+    DDLogDebug(@"Manifest scanning setup completed in %.2f ms", manifestScanTime * 1000.0);
 }
 
 

--- a/MunkiAdmin/NSOperation Subclasses/MARelationshipScanner.m
+++ b/MunkiAdmin/NSOperation Subclasses/MARelationshipScanner.m
@@ -460,6 +460,44 @@ static const int BatchSize = 50;
     //[getPackages setRelationshipKeyPathsForPrefetching:[NSArray arrayWithObjects:@"packageInfos", @"catalogInfos", @"packages", nil]];
     self.allCatalogs = [privateContext executeFetchRequest:getAllCatalogs error:nil];
     
+    // Pre-populate catalog lookup dictionary for fast lookups
+    NSMutableDictionary *catalogsByTitle = [NSMutableDictionary dictionaryWithCapacity:20];
+    for (CatalogMO *catalog in self.allCatalogs) {
+        [catalogsByTitle setObject:catalog forKey:catalog.title];
+    }
+    
+    // Pre-cache IconImageMO objects to eliminate Core Data queries and image processing
+    NSURL *iconsDirectoryURL = [appDelegate iconsURL];
+    NSArray *iconFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:iconsDirectoryURL
+                                                       includingPropertiesForKeys:nil
+                                                                          options:NSDirectoryEnumerationSkipsHiddenFiles
+                                                                            error:nil];
+    NSMutableDictionary *iconImageCache = [NSMutableDictionary dictionaryWithCapacity:[iconFiles count]];
+    
+    for (NSURL *iconURL in iconFiles) {
+        NSString *iconFileName = [iconURL lastPathComponent];
+        IconImageMO *cachedIcon = [[MAMunkiRepositoryManager sharedManager] createIconImageFromURL:iconURL managedObjectContext:privateContext];
+        [iconImageCache setObject:cachedIcon forKey:iconFileName];
+    }
+    
+    // Pre-populate developer lookup dictionary for fast lookups
+    NSFetchRequest *getAllDevelopers = [[NSFetchRequest alloc] init];
+    [getAllDevelopers setEntity:developerEntityDescr];
+    NSArray *allDevelopers = [privateContext executeFetchRequest:getAllDevelopers error:nil];
+    NSMutableDictionary *developersByTitle = [NSMutableDictionary dictionaryWithCapacity:50];
+    for (DeveloperMO *developer in allDevelopers) {
+        [developersByTitle setObject:developer forKey:developer.title];
+    }
+    
+    // Pre-populate category lookup dictionary for fast lookups
+    NSFetchRequest *getAllCategories = [[NSFetchRequest alloc] init];
+    [getAllCategories setEntity:categoryEntityDescr];
+    NSArray *allCategories = [privateContext executeFetchRequest:getAllCategories error:nil];
+    NSMutableDictionary *categoriesByTitle = [NSMutableDictionary dictionaryWithCapacity:30];
+    for (CategoryMO *category in allCategories) {
+        [categoriesByTitle setObject:category forKey:category.title];
+    }
+    
     NSFetchRequest *getApplications = [[NSFetchRequest alloc] init];
     [getApplications setEntity:applicationEntityDescr];
     self.allApplications = [privateContext executeFetchRequest:getApplications error:nil];
@@ -524,24 +562,19 @@ static const int BatchSize = 50;
         DDLogVerbose(@"%@: Looping through catalogs key in the original pkginfo...", currentPackage.titleWithVersion);
         [catalogsFromPkginfo enumerateObjectsUsingBlock:^(id catalogObject, NSUInteger catalogIndex, BOOL *stopCatalogEnum) {
             
-            NSFetchRequest *fetchForCatalogs = [[NSFetchRequest alloc] init];
-            [fetchForCatalogs setEntity:catalogEntityDescr];
-            
-            NSPredicate *catalogTitlePredicate = [NSPredicate predicateWithFormat:@"title == %@", catalogObject];
-            [fetchForCatalogs setPredicate:catalogTitlePredicate];
-            
-            NSUInteger numFoundCatalogs = [privateContext countForFetchRequest:fetchForCatalogs error:nil];
-            
+            // Use dictionary lookup instead of expensive Core Data queries
+            CatalogMO *existingCatalog = [catalogsByTitle objectForKey:catalogObject];
             
             // There is an item in catalogs array which does not
             // yet have it's own CatalogMO object.
             // Create it and add dependencies for it
             
-            if (numFoundCatalogs == 0) {
+            if (existingCatalog == nil) {
                 DDLogVerbose(@"%@: Should be enabled for new catalog %@", currentPackage.titleWithVersion, catalogObject);
                 CatalogMO *aNewCatalog = [NSEntityDescription insertNewObjectForEntityForName:@"Catalog" inManagedObjectContext:privateContext];
                 aNewCatalog.title = catalogObject;
                 [aNewCatalog addPackagesObject:currentPackage];
+                [catalogsByTitle setObject:aNewCatalog forKey:catalogObject];
                 CatalogInfoMO *newCatalogInfo = [NSEntityDescription insertNewObjectForEntityForName:@"CatalogInfo" inManagedObjectContext:privateContext];
                 newCatalogInfo.package = currentPackage;
                 newCatalogInfo.catalog.title = aNewCatalog.title;
@@ -561,7 +594,7 @@ static const int BatchSize = 50;
             // Use the first one and create dependencies if needed
             
             else {
-                CatalogMO *foundCatalog = [[privateContext executeFetchRequest:fetchForCatalogs error:nil] objectAtIndex:0];
+                CatalogMO *foundCatalog = existingCatalog;
                 
                 if (![[currentPackage.catalogInfos valueForKeyPath:@"catalog.title"] containsObject:catalogObject]) {
                     DDLogVerbose(@"%@: Should be enabled for existing catalog %@", currentPackage.titleWithVersion, foundCatalog.title);
@@ -589,46 +622,31 @@ static const int BatchSize = 50;
          use a default icon (which is the icon for .pkg file type).
          */
         if ((currentPackage.munki_icon_name != nil) && (![currentPackage.munki_icon_name isEqualToString:@""])) {
-            NSURL *iconURL = [[appDelegate iconsURL] URLByAppendingPathComponent:currentPackage.munki_icon_name];
-            if ([[iconURL pathExtension] isEqualToString:@""]) {
-                iconURL = [iconURL URLByAppendingPathExtension:@"png"];
+            NSString *iconFileName = currentPackage.munki_icon_name;
+            if ([[iconFileName pathExtension] isEqualToString:@""]) {
+                iconFileName = [iconFileName stringByAppendingPathExtension:@"png"];
             }
-            if ([[NSFileManager defaultManager] fileExistsAtPath:[iconURL path]]) {
-                IconImageMO *icon = [[MAMunkiRepositoryManager sharedManager] createIconImageFromURL:iconURL managedObjectContext:privateContext];
-                currentPackage.iconImage = icon;
-            } else {
-                currentPackage.iconImage = defaultIcon;
-            }
+            IconImageMO *icon = [iconImageCache objectForKey:iconFileName];
+            currentPackage.iconImage = icon ? icon : defaultIcon;
         } else {
-            NSURL *iconURL = [[appDelegate iconsURL] URLByAppendingPathComponent:currentPackage.munki_name];
-            iconURL = [iconURL URLByAppendingPathExtension:@"png"];
-            if ([[NSFileManager defaultManager] fileExistsAtPath:[iconURL path]]) {
-                IconImageMO *icon = [[MAMunkiRepositoryManager sharedManager] createIconImageFromURL:iconURL managedObjectContext:privateContext];
-                currentPackage.iconImage = icon;
-            } else {
-                currentPackage.iconImage = defaultIcon;
-            }
+            NSString *iconFileName = [currentPackage.munki_name stringByAppendingPathExtension:@"png"];
+            IconImageMO *icon = [iconImageCache objectForKey:iconFileName];
+            currentPackage.iconImage = icon ? icon : defaultIcon;
         }
         
         /*
          Deal with the package category
          */
         if ([originalPkginfo objectForKey:@"category"] != nil) {
-            NSFetchRequest *fetchForCategory = [[NSFetchRequest alloc] init];
-            [fetchForCategory setEntity:categoryEntityDescr];
-            
-            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"title == %@", [originalPkginfo objectForKey:@"category"]];
-            [fetchForCategory setPredicate:predicate];
-            
-            NSUInteger numFoundCategories = [privateContext countForFetchRequest:fetchForCategory error:nil];
-            CategoryMO *category = nil;
-            if (numFoundCategories > 0) {
-                category = [[privateContext executeFetchRequest:fetchForCategory error:nil] objectAtIndex:0];
+            NSString *categoryTitle = [originalPkginfo objectForKey:@"category"];
+            CategoryMO *category = [categoriesByTitle objectForKey:categoryTitle];
+            if (category) {
                 [category addPackagesObject:currentPackage];
             } else {
                 category = [NSEntityDescription insertNewObjectForEntityForName:@"Category" inManagedObjectContext:privateContext];
-                category.title = [originalPkginfo objectForKey:@"category"];
+                category.title = categoryTitle;
                 [category addPackagesObject:currentPackage];
+                [categoriesByTitle setObject:category forKey:categoryTitle];
             }
         }
         
@@ -636,21 +654,15 @@ static const int BatchSize = 50;
          Deal with the package developer
          */
         if ([originalPkginfo objectForKey:@"developer"] != nil) {
-            NSFetchRequest *fetchForDeveloper = [[NSFetchRequest alloc] init];
-            [fetchForDeveloper setEntity:developerEntityDescr];
-            
-            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"title == %@", [originalPkginfo objectForKey:@"developer"]];
-            [fetchForDeveloper setPredicate:predicate];
-            
-            NSUInteger numFoundDevelopers = [privateContext countForFetchRequest:fetchForDeveloper error:nil];
-            DeveloperMO *developer = nil;
-            if (numFoundDevelopers > 0) {
-                developer = [[privateContext executeFetchRequest:fetchForDeveloper error:nil] objectAtIndex:0];
+            NSString *developerTitle = [originalPkginfo objectForKey:@"developer"];
+            DeveloperMO *developer = [developersByTitle objectForKey:developerTitle];
+            if (developer) {
                 [developer addPackagesObject:currentPackage];
             } else {
                 developer = [NSEntityDescription insertNewObjectForEntityForName:@"Developer" inManagedObjectContext:privateContext];
-                developer.title = [originalPkginfo objectForKey:@"developer"];
+                developer.title = developerTitle;
                 [developer addPackagesObject:currentPackage];
+                [developersByTitle setObject:developer forKey:developerTitle];
             }
         }
         

--- a/MunkiAdmin/NSOperation Subclasses/MARelationshipScanner.m
+++ b/MunkiAdmin/NSOperation Subclasses/MARelationshipScanner.m
@@ -710,6 +710,8 @@ static const int BatchSize = 50;
 
 
 - (void)main {
+    NSDate *relationshipScanStartTime = [NSDate date];
+    
     self.context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
     self.context.parentContext = [(MAMunkiAdmin_AppDelegate *)self.delegate managedObjectContext];
     self.context.undoManager = nil;
@@ -732,6 +734,10 @@ static const int BatchSize = 50;
             // Do not rethrow exceptions.
         }
     }];
+    
+    NSTimeInterval relationshipScanTime = [[NSDate date] timeIntervalSinceDate:relationshipScanStartTime];
+    NSString *scanType = (self.operationMode == 0) ? @"package" : @"manifest";
+    DDLogDebug(@"Relationship scanning (%@) completed in %.2f ms", scanType, relationshipScanTime * 1000.0);
 }
 
 @end


### PR DESCRIPTION
This pull request optimizes MunkiAdmin's performance when loading large Munki repositories by eliminating Core Data query bottlenecks and expensive object creation operations.

With my organization's repository containing 1000+ packages, these changes reduced loading time from 10.0 seconds to 2.1 seconds. (On macOS 26.0, running Xcode 26.0.1.)

I had some help solving this with an AI assistant, which helped break down the initial load time observations as follows:

| Operation             | Time (ms) | Percentage | 
| --------------------- | --------- | ---------- |
| Catalog Processing    | 2,287     | 26.9%      | 
| Icon Processing       | 2,070     | 24.3%      | 
| Developer Processing  | 1,787     | 21.0%      | 
| Category Processing   | 1,286     | 15.1%      | 
| **Total Bottlenecks** | **7,430** | **87.3%**  | 

The solution ended up being four similar improvements involving dictionary caching.

### 1. Catalog Dictionary Caching

- **Problem**: ~3,432 Core Data queries executed for catalog lookups
- **Solution**: Pre-populate lookup dictionary, replace queries with O(1) lookups
- **Result**: 99.8% improvement (2,287ms → 5ms)

### 2. IconImageMO Object Caching

- **Problem**: ~1,144 expensive `createIconImageFromURL` calls with file I/O and image processing
- **Solution**: Pre-cache all IconImageMO objects during initialization
- **Result**: 99.6% improvement (2,070ms → 9ms)

### 3. Developer Dictionary Caching

- **Problem**: ~1,144 Core Data queries for developer object lookups
- **Solution**: Pre-populate lookup dictionary, replace queries with O(1) lookups
- **Result**: 99.5% improvement (1,787ms → 8ms)

### 4. Category Dictionary Caching

- **Problem**: ~1,144 Core Data queries for category object lookups
- **Solution**: Pre-populate lookup dictionary, replace queries with O(1) lookups
- **Result**: 99.5% improvement (1,286ms → 7ms)

After these changes were made, I observed a significant improvement:

| Metric             | Before  | After   | Improvement       |
| ------------------ | ------- | ------- | ----------------- |
| Package Processing | 8,645ms | 1,427ms | -83.5% (-7,218ms) |
| Total Loading Time | ~10.0s  | ~2.1s   | -79% (-7.9s)      |
| Core Data Queries  | ~5,725  | ~29     | -99.5% (-5,696)   |

These changes contributed to an **overall 79% improvement in loading time** across multiple test runs, including both initial load and reloading (using Command-R). The difference was very noticeable.

No significant changes in memory usage was observed after these changes. The changes should follow existing code patterns, and should maintain full backward compatibility with all macOS versions that run MunkiAdmin.

I'm hopeful this may have similar benefits for others with large Munki repos. Thanks for considering!