### PR TITLE
Scalable row size for the main tables

### DIFF
--- a/MunkiAdmin/Base.lproj/MainMenu.xib
+++ b/MunkiAdmin/Base.lproj/MainMenu.xib
@@ -481,6 +481,33 @@ Gw
                                     <action selector="runToolbarCustomizationPalette:" target="-1" id="343"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="rs-sep-001"/>
+                            <menuItem title="Row Size" id="rs-submenu-root">
+                                <menu key="submenu" title="Row Size" id="rs-submenu-menu">
+                                    <items>
+                                        <menuItem title="Small" tag="0" id="rs-size-small">
+                                            <connections>
+                                                <action selector="changeMainTableRowSize:" target="205" id="rs-action-small"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Medium" tag="1" id="rs-size-medium">
+                                            <connections>
+                                                <action selector="changeMainTableRowSize:" target="205" id="rs-action-medium"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Large" tag="2" id="rs-size-large">
+                                            <connections>
+                                                <action selector="changeMainTableRowSize:" target="205" id="rs-action-large"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Extra Large" tag="3" id="rs-size-xlarge">
+                                            <connections>
+                                                <action selector="changeMainTableRowSize:" target="205" id="rs-action-xlarge"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                         </items>
                     </menu>
                 </menuItem>

--- a/MunkiAdmin/MAMunkiAdmin_AppDelegate.h
+++ b/MunkiAdmin/MAMunkiAdmin_AppDelegate.h
@@ -29,6 +29,29 @@
 @class DDFileLogger;
 
 
+// Controls the row height and font size of the main Packages and Manifests
+// tables. Stored as an integer index in NSUserDefaults under the
+// "mainTableRowSize" key. The default value (0) preserves the historical
+// appearance; larger values are intended for use on high-resolution displays.
+NS_INLINE CGFloat MAMainTableFontSizeForRowSize(NSInteger rowSize) {
+    switch (rowSize) {
+        case 1:  return 13.0;
+        case 2:  return 16.0;
+        case 3:  return 19.0;
+        default: return [NSFont smallSystemFontSize];
+    }
+}
+
+NS_INLINE CGFloat MAMainTableRowHeightForRowSize(NSInteger rowSize) {
+    switch (rowSize) {
+        case 1:  return 20.0;
+        case 2:  return 26.0;
+        case 3:  return 32.0;
+        default: return 17.0;
+    }
+}
+
+
 @interface MAMunkiAdmin_AppDelegate : NSObject <NSApplicationDelegate, NSTabViewDelegate, NSSplitViewDelegate, NSOpenSavePanelDelegate, NSToolbarDelegate>
 {
     MASelectPkginfoItemsWindow *addItemsWindowController;
@@ -163,6 +186,7 @@
 - (IBAction)startPkginfoAssimilatorAction:(id)sender;
 - (IBAction)openCurrentLogFileAction:(id)sender;
 - (IBAction)findAction:(id)sender;
+- (IBAction)changeMainTableRowSize:(id)sender;
 
 # pragma mark -
 # pragma mark Helper methods

--- a/MunkiAdmin/MAMunkiAdmin_AppDelegate.m
+++ b/MunkiAdmin/MAMunkiAdmin_AppDelegate.m
@@ -52,6 +52,23 @@ DDLogLevel ddLogLevel;
     }
 }
 
+- (IBAction)changeMainTableRowSize:(id)sender
+{
+    DDLogVerbose(@"%@", NSStringFromSelector(_cmd));
+    NSInteger newSize = [(NSMenuItem *)sender tag];
+    [[NSUserDefaults standardUserDefaults] setInteger:newSize forKey:@"mainTableRowSize"];
+}
+
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
+{
+    if ([menuItem action] == @selector(changeMainTableRowSize:)) {
+        NSInteger currentSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"mainTableRowSize"];
+        [menuItem setState:([menuItem tag] == currentSize) ? NSControlStateValueOn : NSControlStateValueOff];
+        return YES;
+    }
+    return YES;
+}
+
 - (IBAction)openCurrentLogFileAction:(id)sender
 {
     DDLogVerbose(@"%@", NSStringFromSelector(_cmd));

--- a/MunkiAdmin/UI Controllers/MAManifestsView.m
+++ b/MunkiAdmin/UI Controllers/MAManifestsView.m
@@ -335,6 +335,16 @@ DDLogLevel ddLogLevel;
                                              forKeyPath:@"arrangedObjects"
                                                 options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
                                                 context:NULL];
+
+    /*
+     Observe the user-controlled row size for the manifests table and apply
+     the current value on launch.
+     */
+    [[NSUserDefaultsController sharedUserDefaultsController] addObserver:self
+                                                              forKeyPath:@"values.mainTableRowSize"
+                                                                 options:0
+                                                                 context:NULL];
+    [self applyMainTableRowSize];
     
     /*
      Configure sorting
@@ -1081,11 +1091,53 @@ DDLogLevel ddLogLevel;
 # pragma mark -
 # pragma mark NSTableView delegate
 
+- (void)applyFontToRowView:(NSTableRowView *)rowView
+{
+    NSInteger rowSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"mainTableRowSize"];
+    NSFont *font = [NSFont systemFontOfSize:MAMainTableFontSizeForRowSize(rowSize)];
+    CGFloat rowHeight = MAMainTableRowHeightForRowSize(rowSize);
+    for (NSInteger col = 0; col < rowView.numberOfColumns; col++) {
+        NSView *cellView = [rowView viewAtColumn:col];
+        for (NSView *subview in cellView.subviews) {
+            if ([subview isKindOfClass:[NSTextField class]]) {
+                NSTextField *textField = (NSTextField *)subview;
+                [textField setFont:font];
+                // The xib pins text fields to a fixed 17pt height with
+                // flexibleMinY autoresizing, so they don't grow with the
+                // cell. Set the height explicitly to the current row height
+                // so larger fonts aren't clipped and so toggling back to a
+                // smaller size doesn't leave the field oversized.
+                NSRect frame = textField.frame;
+                frame.origin.y = 0;
+                frame.size.height = rowHeight;
+                textField.frame = frame;
+            }
+        }
+    }
+}
+
+- (void)applyMainTableRowSize
+{
+    NSInteger rowSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"mainTableRowSize"];
+    self.manifestsListTableView.rowSizeStyle = NSTableViewRowSizeStyleCustom;
+    self.manifestsListTableView.rowHeight = MAMainTableRowHeightForRowSize(rowSize);
+    [self.manifestsListTableView enumerateAvailableRowViewsUsingBlock:^(NSTableRowView *rowView, NSInteger row) {
+        [self applyFontToRowView:rowView];
+    }];
+}
+
 - (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
 {
     NSString *identifier = [tableColumn identifier];
     NSView *cellView = [tableView makeViewWithIdentifier:identifier owner:nil];
     return cellView;
+}
+
+- (void)tableView:(NSTableView *)tableView didAddRowView:(NSTableRowView *)rowView forRow:(NSInteger)row
+{
+    if (tableView == self.manifestsListTableView) {
+        [self applyFontToRowView:rowView];
+    }
 }
 
 - (id<NSPasteboardWriting>)tableView:(NSTableView *)tableView pasteboardWriterForRow:(NSInteger)row
@@ -1561,6 +1613,10 @@ DDLogLevel ddLogLevel;
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
 {
+    if ([keyPath isEqualToString:@"values.mainTableRowSize"]) {
+        [self applyMainTableRowSize];
+        return;
+    }
     if (object == self.manifestSourceListTreeController && [keyPath isEqualToString:@"arrangedObjects"]) {
         DDLogVerbose(@"Sidebar tree controller content changed");
         // React to sidebar content changes here
@@ -1588,6 +1644,11 @@ DDLogLevel ddLogLevel;
 {
     @try {
         [self.manifestSourceListTreeController removeObserver:self forKeyPath:@"arrangedObjects"];
+    } @catch (NSException *exception) {
+        DDLogError(@"Exception removing observer: %@", exception.reason);
+    }
+    @try {
+        [[NSUserDefaultsController sharedUserDefaultsController] removeObserver:self forKeyPath:@"values.mainTableRowSize"];
     } @catch (NSException *exception) {
         DDLogError(@"Exception removing observer: %@", exception.reason);
     }

--- a/MunkiAdmin/UI Controllers/MAPackagesView.m
+++ b/MunkiAdmin/UI Controllers/MAPackagesView.m
@@ -126,6 +126,16 @@ DDLogLevel ddLogLevel;
     
     [self.descriptionTextView setFont:[NSFont systemFontOfSize:11.0]];
     [self.notesTextView setFont:[NSFont systemFontOfSize:11.0]];
+
+    /*
+     Observe the user-controlled row size for the packages table and apply
+     the current value on launch.
+     */
+    [[NSUserDefaultsController sharedUserDefaultsController] addObserver:self
+                                                              forKeyPath:@"values.mainTableRowSize"
+                                                                 options:0
+                                                                 context:NULL];
+    [self applyMainTableRowSize];
     
     /*
      Configure the main triple split view (sourcelist | packagelist | info)
@@ -1422,6 +1432,48 @@ DDLogLevel ddLogLevel;
 # pragma mark -
 # pragma mark NSTableView delegates
 
+- (void)applyFontToRowView:(NSTableRowView *)rowView
+{
+    NSInteger rowSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"mainTableRowSize"];
+    NSFont *font = [NSFont systemFontOfSize:MAMainTableFontSizeForRowSize(rowSize)];
+    CGFloat rowHeight = MAMainTableRowHeightForRowSize(rowSize);
+    for (NSInteger col = 0; col < rowView.numberOfColumns; col++) {
+        NSView *cellView = [rowView viewAtColumn:col];
+        for (NSView *subview in cellView.subviews) {
+            if ([subview isKindOfClass:[NSTextField class]]) {
+                NSTextField *textField = (NSTextField *)subview;
+                [textField setFont:font];
+                // The xib pins text fields to a fixed 17pt height with
+                // flexibleMinY autoresizing, so they don't grow with the
+                // cell. Set the height explicitly to the current row height
+                // so larger fonts aren't clipped and so toggling back to a
+                // smaller size doesn't leave the field oversized.
+                NSRect frame = textField.frame;
+                frame.origin.y = 0;
+                frame.size.height = rowHeight;
+                textField.frame = frame;
+            }
+        }
+    }
+}
+
+- (void)applyMainTableRowSize
+{
+    NSInteger rowSize = [[NSUserDefaults standardUserDefaults] integerForKey:@"mainTableRowSize"];
+    self.packagesTableView.rowSizeStyle = NSTableViewRowSizeStyleCustom;
+    self.packagesTableView.rowHeight = MAMainTableRowHeightForRowSize(rowSize);
+    [self.packagesTableView enumerateAvailableRowViewsUsingBlock:^(NSTableRowView *rowView, NSInteger row) {
+        [self applyFontToRowView:rowView];
+    }];
+}
+
+- (void)tableView:(NSTableView *)tableView didAddRowView:(NSTableRowView *)rowView forRow:(NSInteger)row
+{
+    if (tableView == self.packagesTableView) {
+        [self applyFontToRowView:rowView];
+    }
+}
+
 - (id<NSPasteboardWriting>)tableView:(NSTableView *)tableView pasteboardWriterForRow:(NSInteger)row
 {
     if (tableView == self.packagesTableView) {
@@ -1629,6 +1681,24 @@ DDLogLevel ddLogLevel;
         
         [top setFrame:topFrame];
         [bottom setFrame:bottomFrame];
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
+{
+    if ([keyPath isEqualToString:@"values.mainTableRowSize"]) {
+        [self applyMainTableRowSize];
+    } else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
+}
+
+- (void)dealloc
+{
+    @try {
+        [[NSUserDefaultsController sharedUserDefaultsController] removeObserver:self forKeyPath:@"values.mainTableRowSize"];
+    } @catch (NSException *exception) {
+        DDLogError(@"Exception removing observer: %@", exception.reason);
     }
 }
 

--- a/MunkiAdmin/UserDefaults.plist
+++ b/MunkiAdmin/UserDefaults.plist
@@ -260,6 +260,8 @@
 	<integer>30</integer>
 	<key>atomicWrites</key>
 	<true/>
+	<key>mainTableRowSize</key>
+	<integer>0</integer>
 	<key>iconResizeDefaultWidth</key>
 	<integer>350</integer>
 	<key>iconResizeDefaultHeight</key>


### PR DESCRIPTION
## What

Partially addresses #216.

Adds a **View > Row Size** submenu with four options — Small, Medium, Large,
Extra Large — that scale the row height and cell font of the two main list
tables:

- the Packages table in the Packages view
- the Manifests table in the Manifests view

The selected size is stored in `NSUserDefaults` under the `mainTableRowSize`
key. The default value is Small, which matches the existing visual
appearance, so users see no change until they pick a larger size from the
menu.

## Why

The default cell text can be hard to read on a high-resolution display.
This is a small, opt-in way to make the main repo listings more legible
without touching the rest of the interface.

## Approach

- One new `IBAction` (`changeMainTableRowSize:`) and a `validateMenuItem:`
  on `MAMunkiAdmin_AppDelegate` that handle the menu action and put a
  check mark on the active size.
- Two `NS_INLINE` helpers in `MAMunkiAdmin_AppDelegate.h` map the row-size
  index to a font size and a row height.
- `MAPackagesView` and `MAManifestsView` observe
  `values.mainTableRowSize` via `NSUserDefaultsController`. On change (and
  on launch) they set `rowHeight` on the table and, for every visible
  row's cell views, set both the font and the height of each text field
  so taller fonts aren't clipped. `tableView:didAddRowView:forRow:`
  re-applies the same to rows recycled during scrolling.

The text-field resize is needed because the cells in both xibs pin their
text fields to a fixed 17pt height with `flexibleMinY` autoresizing —
making the row taller doesn't make the text field any taller, and the
larger glyphs would be clipped at the bottom of each row.

## Deliberately out of scope

To keep the diff small and reviewable, this PR does **not**:

- Add Command-+ / Command-- keybindings.
- Scale sidebars, toolbars, the detail/editor panes, or modal dialogs.
  Scaling those is much more invasive (AppKit does not reflow on font
  changes) and felt like a separate change.
- Scale the table column headers — only the data rows.
- Scale icons inside cells.
- Touch the Preferences pane — the setting is set from the View menu only.

## A note for future maintenance

The text-field resize in `applyFontToRowView:` works because the xib cells
use fixed frames + autoresizing (`translatesAutoresizingMaskIntoConstraints`
is left as the migration default and there are no real constraints on the
text fields). If a future refactor adds Auto Layout constraints to those
cells, the direct `textField.frame = …` assignment will silently stop
having an effect and would need to be replaced with constraint updates or
an `intrinsicContentSize` override.

## Try it

1. Build and run.
2. Open **View > Row Size** and pick Medium, Large, or Extra Large.
3. Both the Packages and Manifests tables should grow; the active size
   gets a check mark in the menu.
4. Pick Small again to return to the previous appearance.

## Files changed

- `MunkiAdmin/UserDefaults.plist` — new default `mainTableRowSize = 0`
- `MunkiAdmin/Base.lproj/MainMenu.xib` — new submenu under View
- `MunkiAdmin/MAMunkiAdmin_AppDelegate.{h,m}` — action, validation, and
  size-table helpers
- `MunkiAdmin/UI Controllers/MAPackagesView.m` — apply size to
  `packagesTableView`
- `MunkiAdmin/UI Controllers/MAManifestsView.m` — apply size to
  `manifestsListTableView`
